### PR TITLE
Hide Canvas Artifacts with Border-Radius

### DIFF
--- a/website/pages/index.mdx
+++ b/website/pages/index.mdx
@@ -119,6 +119,7 @@ export function Cobe() {
         contain: 'layout paint size',
         opacity: 0,
         transition: 'opacity 1s ease',
+        borderRadius: '50%',
       }}
     />
   </div>


### PR DESCRIPTION
I recently noticed there are some artifacts around the globe.

<img width="1792" alt="Screen Shot 2022-06-26 at 11 39 48 PM" src="https://user-images.githubusercontent.com/31657298/175876587-543a53b5-0b9f-4004-851b-21d5ccb0721b.png">

You can see it better when you brighten up the image. See that square line?

![Screen Shot 2022-06-26 at 11 39 48 PM 2](https://user-images.githubusercontent.com/31657298/175876706-3e9c965e-34a7-4ef9-9022-7fab88886c4d.jpeg)

I investigated the issue and figured that one can simply remove this with `border-radius: 50%`.

<img width="1792" alt="Screen Shot 2022-06-26 at 11 40 23 PM" src="https://user-images.githubusercontent.com/31657298/175876797-15effaf1-41a9-4582-99ce-f9dcd29254c9.png">

