### PR TITLE
Fix unsupported `experimental-webgl` context type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,7 @@ export default (canvas, opts) => {
 
   const p = new Phenomenon({
     canvas,
+    contextType: 'webgl',
     context: {
       alpha: true,
       stencil: false,

--- a/src/index.js
+++ b/src/index.js
@@ -52,9 +52,12 @@ export default (canvas, opts) => {
     }
   }
 
+  // See https://github.com/shuding/cobe/pull/34.
+  const contextType = canvas.getContext('webgl') ? 'webgl' : 'experimental-webgl'
+
   const p = new Phenomenon({
     canvas,
-    contextType: 'webgl',
+    contextType,
     context: {
       alpha: true,
       stencil: false,


### PR DESCRIPTION
Closes #33.

According to https://caniuse.com/webgl several browsers still depend on `experimental-webgl` including IE 11.