### PR TITLE
z-index added

### DIFF
--- a/website/pages/playground.mdx
+++ b/website/pages/playground.mdx
@@ -102,7 +102,7 @@ export function Page() {
   }, [])
   return (
     <>
-      <div style={{ position: 'absolute', right: 20, top: 20 }}>
+      <div style={{ position: 'absolute', right: 20, top: 20, z-index: 1 }}>
         <Leva fill />
       </div>
       <canvas


### PR DESCRIPTION
**Minor fix:**
z-index: 1 added to settings at website/playground.mdx because text and sliders wasnt't in a lower level than menu.

Fixed:
![Screenshot 2023-04-12 140618_fixed](https://user-images.githubusercontent.com/40320458/231439527-ce428270-abf2-42bc-aaa2-1f4b0fa687ff.png)

Old:
![Screenshot 2023-04-12 140705_old](https://user-images.githubusercontent.com/40320458/231439531-e078bbe0-987b-4e65-ae2a-a84f49bef0c4.png)
