### PR TITLE
feat: use webgl2 if supported

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,9 +57,11 @@ export default (canvas, opts) => {
   }
 
   // See https://github.com/shuding/cobe/pull/34.
-  const contextType = canvas.getContext('webgl')
-    ? 'webgl'
-    : 'experimental-webgl'
+  const contextType = canvas.getContext("webgl2")
+    ? "webgl2"
+    : canvas.getContext("webgl")
+    ? "webgl"
+    : "experimental-webgl";
 
   const p = new Phenomenon({
     canvas,


### PR DESCRIPTION
WebGL2 is now [relatively prevalent](https://caniuse.com/webgl2) and should probably be used if supported.