### PR TITLE
fix improper link to example

### DIFF
--- a/website/pages/docs/showcases/draggable-and-rotate.mdx
+++ b/website/pages/docs/showcases/draggable-and-rotate.mdx
@@ -108,4 +108,4 @@ export function Cobe() {
 
 Change the `phi` value over time or when moving on the canvas, with [React Spring](https://react-spring.dev) to smoothen it.
 
-[View source of this example on GitHub](https://github.com/shuding/cobe/blob/main/website/pages/docs/showcases/draggable.mdx)
+[View source of this example on GitHub](https://github.com/shuding/cobe/blob/main/website/pages/docs/showcases/draggable-and-rotate.mdx)


### PR DESCRIPTION
Current [link](https://cobe.vercel.app/docs/showcases/draggable-and-rotate) points to the draggable component.

![Screenshot 2023-09-28 at 10 42 51 AM](https://github.com/shuding/cobe/assets/28717686/49ae24af-d041-4e31-ae1d-db8fb486cefc)
