### PR TITLE
Add console warnings when WebGL is unavailable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,12 @@ export default (canvas, opts) => {
   const webgl2 = !!gl
   if (!gl) gl = canvas.getContext('webgl', contextOpts)
 
-  if (!gl) return { destroy: () => {}, update: () => {} }
+  if (!gl) {
+    console.warn(
+      'COBE: WebGL is not supported in this browser or device. The globe will not be rendered.',
+    )
+    return { destroy: () => {}, update: () => {} }
+  }
 
   const instExt = webgl2 ? null : gl.getExtension('ANGLE_instanced_arrays')
 
@@ -87,7 +92,12 @@ export default (canvas, opts) => {
   const markerProgram = createProgram(gl, MARKER_VERT, MARKER_FRAG)
   const arcProgram = createProgram(gl, ARC_VERT, ARC_FRAG)
 
-  if (!globeProgram) return { destroy: () => {}, update: () => {} }
+  if (!globeProgram) {
+    console.warn(
+      'COBE: Failed to compile WebGL shaders. The globe will not be rendered.',
+    )
+    return { destroy: () => {}, update: () => {} }
+  }
 
   // Buffers
   const quadBuffer = gl.createBuffer()
@@ -591,10 +601,29 @@ export default (canvas, opts) => {
   // Initialize
   update({ markers, arcs })
 
+  // Handle WebGL context loss
+  const onContextLost = (e) => {
+    e.preventDefault()
+    console.warn(
+      'COBE: WebGL context lost. The globe will stop rendering. This can happen due to GPU resource limits or device sleep.',
+    )
+  }
+  const onContextRestored = () => {
+    console.warn(
+      'COBE: WebGL context restored. Please re-create the globe instance to resume rendering.',
+    )
+  }
+  canvas.addEventListener('webglcontextlost', onContextLost)
+  canvas.addEventListener('webglcontextrestored', onContextRestored)
+
   // Return public API
   return {
     update,
     destroy: () => {
+      // Clean up event listeners
+      canvas.removeEventListener('webglcontextlost', onContextLost)
+      canvas.removeEventListener('webglcontextrestored', onContextRestored)
+
       // Clean up WebGL resources
       gl.deleteBuffer(quadBuffer)
       gl.deleteBuffer(arcSegmentBuffer)


### PR DESCRIPTION
## Summary

- Add `console.warn` when neither WebGL2 nor WebGL1 context can be obtained (unsupported browser/device)
- Add `console.warn` when shader programs fail to compile
- Add `webglcontextlost` / `webglcontextrestored` event listeners to warn on runtime context loss
- Properly clean up event listeners in `destroy()`

Previously, all WebGL failures silently returned no-op objects, making it difficult for developers to understand why the globe wasn't rendering.

## Test plan

- [x] Verify warning appears in console when WebGL is disabled (e.g., via browser flags or in a non-WebGL environment)
- [x] Verify warning appears when WebGL context is lost (can be simulated via `WEBGL_lose_context` extension)
- [x] Verify no warnings appear during normal operation
- [x] Verify event listeners are cleaned up after `destroy()` is called