### PR TITLE
feat: per-arc endpoint elevation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ const globe = createGlobe(canvas, {
   markers: [
     { location: [37.7595, -122.4367], size: 0.03 },
     { location: [40.7128, -74.006], size: 0.1, color: [1, 0, 0] }, // custom color
+    { location: [51.5074, -0.1278], size: 0.05, elevation: 0.15 }, // custom elevation
   ],
   arcs: [
     {

--- a/src/anchor.js
+++ b/src/anchor.js
@@ -46,7 +46,7 @@ export function createAnchorManager(wrapper) {
       const key = marker.id
       if (!key) continue
 
-      const pos = project(marker.location)
+      const pos = project(marker.location, marker.elevation)
 
       activeKeys[key] = 1
 

--- a/src/arc.glslx
+++ b/src/arc.glslx
@@ -19,6 +19,10 @@ attribute float aArcHeight;
 attribute float aArcWidth;
 attribute vec3 aArcColor;
 attribute float aHasColor;
+attribute float aArcFromElevation;
+attribute float aArcFromHasElevation;
+attribute float aArcToElevation;
+attribute float aArcToHasElevation;
 
 // Uniforms
 uniform float phi;
@@ -53,9 +57,10 @@ vec3 bezierTangent(vec3 p0, vec3 p1, vec3 p2, float t) {
 void vertex() {
   mat3 rot = rotate(theta, phi);
 
-  float endpointR = GLOBE_R + markerElevation;
-  vec3 from = aArcFrom * endpointR;
-  vec3 to = aArcTo * endpointR;
+  float fromR = aArcFromHasElevation > 0.5 ? GLOBE_R + aArcFromElevation : GLOBE_R + markerElevation;
+  float toR = aArcToHasElevation > 0.5 ? GLOBE_R + aArcToElevation : GLOBE_R + markerElevation;
+  vec3 from = aArcFrom * fromR;
+  vec3 to = aArcTo * toR;
 
   vec3 midSum = aArcFrom + aArcTo;
   float midLen = length(midSum);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,6 +11,8 @@ export interface Arc {
   to: [number, number]
   color?: [number, number, number]
   id?: string
+  fromElevation?: number
+  toElevation?: number
 }
 
 export interface COBEOptions {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,6 +2,7 @@ export interface Marker {
   location: [number, number]
   size: number
   color?: [number, number, number]
+  elevation?: number
   id?: string
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -168,6 +168,10 @@ export default (canvas, opts) => {
     ARC_aArcWidth,
     ARC_aArcColor,
     ARC_aHasColor,
+    ARC_aArcFromElevation,
+    ARC_aArcFromHasElevation,
+    ARC_aArcToElevation,
+    ARC_aArcToHasElevation,
   ])
 
   // Globe attribute
@@ -245,8 +249,8 @@ export default (canvas, opts) => {
     arcs = newArcs
     validArcCount = arcs.length
 
-    // 12 floats per arc: from(3), to(3), height, width, color(3), hasColor
-    const arcData = new Float32Array(arcs.length * 12)
+    // 16 floats per arc: from(3), to(3), height, width, color(3), hasColor, fromElevation, hasFromElevation, toElevation, hasToElevation
+    const arcData = new Float32Array(arcs.length * 16)
 
     arcs.forEach((arc, i) => {
       arcData.set(
@@ -257,8 +261,12 @@ export default (canvas, opts) => {
           arcWidth * 0.005,
           ...(arc.color || [0, 0, 0]),
           arc.color ? 1 : 0,
+          arc.fromElevation ?? 0,
+          arc.fromElevation != null ? 1 : 0,
+          arc.toElevation ?? 0,
+          arc.toElevation != null ? 1 : 0,
         ],
-        i * 12,
+        i * 16,
       )
     })
 
@@ -489,7 +497,7 @@ export default (canvas, opts) => {
 
       // Bind instance buffer
       gl.bindBuffer(gl.ARRAY_BUFFER, arcInstanceBuffer)
-      const arcStride = 12 * 4 // 12 floats * 4 bytes
+      const arcStride = 16 * 4 // 16 floats * 4 bytes
 
       setupInstancedAttribute(arcAttribs[ARC_aArcFrom], 3, arcStride, 0, 1)
       setupInstancedAttribute(arcAttribs[ARC_aArcTo], 3, arcStride, 12, 1)
@@ -497,6 +505,10 @@ export default (canvas, opts) => {
       setupInstancedAttribute(arcAttribs[ARC_aArcWidth], 1, arcStride, 28, 1)
       setupInstancedAttribute(arcAttribs[ARC_aArcColor], 3, arcStride, 32, 1)
       setupInstancedAttribute(arcAttribs[ARC_aHasColor], 1, arcStride, 44, 1)
+      setupInstancedAttribute(arcAttribs[ARC_aArcFromElevation], 1, arcStride, 48, 1)
+      setupInstancedAttribute(arcAttribs[ARC_aArcFromHasElevation], 1, arcStride, 52, 1)
+      setupInstancedAttribute(arcAttribs[ARC_aArcToElevation], 1, arcStride, 56, 1)
+      setupInstancedAttribute(arcAttribs[ARC_aArcToHasElevation], 1, arcStride, 60, 1)
 
       // Set uniforms
       gl.uniform1f(arcUniforms[ARC_phi], phi)

--- a/src/index.js
+++ b/src/index.js
@@ -144,6 +144,8 @@ export default (canvas, opts) => {
     MARKER_aMarkerSize,
     MARKER_aMarkerColor,
     MARKER_aHasColor,
+    MARKER_aMarkerElevation,
+    MARKER_aHasElevation,
   ])
 
   // Arc uniforms
@@ -212,8 +214,8 @@ export default (canvas, opts) => {
   function updateMarkers(newMarkers) {
     markers = newMarkers
 
-    // 8 floats per marker: x, y, z, size, r, g, b, hasColor
-    const markerData = new Float32Array(markers.length * 8)
+    // 10 floats per marker: x, y, z, size, r, g, b, hasColor, elevation, hasElevation
+    const markerData = new Float32Array(markers.length * 10)
 
     markers.forEach((m, i) => {
       markerData.set(
@@ -222,8 +224,10 @@ export default (canvas, opts) => {
           m.size,
           ...(m.color || [0, 0, 0]),
           m.color ? 1 : 0,
+          m.elevation ?? 0,
+          m.elevation != null ? 1 : 0,
         ],
-        i * 8,
+        i * 10,
       )
     })
 
@@ -292,10 +296,12 @@ export default (canvas, opts) => {
 
   /**
    * Project a location to screen coordinates
+   * @param {[number, number]} location
+   * @param {number} [elevation] - per-marker elevation override
    */
-  function project(location) {
+  function project(location, elevation) {
     const pos3D = latLonTo3D(location)
-    const r = GLOBE_R + markerElevation
+    const r = GLOBE_R + (elevation != null ? elevation : markerElevation)
     const elevatedPos = [pos3D[0] * r, pos3D[1] * r, pos3D[2] * r]
 
     const rotated = applyRotation(elevatedPos)
@@ -551,7 +557,7 @@ export default (canvas, opts) => {
 
       // Bind instance buffer
       gl.bindBuffer(gl.ARRAY_BUFFER, markerInstanceBuffer)
-      const markerStride = 8 * 4 // 8 floats * 4 bytes
+      const markerStride = 10 * 4 // 10 floats * 4 bytes
 
       setupInstancedAttribute(
         markerAttribs[MARKER_aMarkerPos],
@@ -579,6 +585,20 @@ export default (canvas, opts) => {
         1,
         markerStride,
         28,
+        1,
+      )
+      setupInstancedAttribute(
+        markerAttribs[MARKER_aMarkerElevation],
+        1,
+        markerStride,
+        32,
+        1,
+      )
+      setupInstancedAttribute(
+        markerAttribs[MARKER_aHasElevation],
+        1,
+        markerStride,
+        36,
         1,
       )
 

--- a/src/marker.glslx
+++ b/src/marker.glslx
@@ -12,6 +12,8 @@ attribute vec3 aMarkerPos;
 attribute float aMarkerSize;
 attribute vec3 aMarkerColor;
 attribute float aHasColor;
+attribute float aMarkerElevation;
+attribute float aHasElevation;
 
 uniform float phi;
 uniform float theta;
@@ -23,7 +25,8 @@ uniform float markerElevation;
 void vertex() {
   float cx = cos(theta), sx = sin(theta);
   float cy = cos(phi), sy = sin(phi);
-  vec3 p = aMarkerPos * (0.8 + markerElevation);
+  float elev = aHasElevation > 0.5 ? aMarkerElevation : markerElevation;
+  vec3 p = aMarkerPos * (0.8 + elev);
   vec3 rp = vec3(
     cy * p.x + sy * p.z,
     sy * sx * p.x + cx * p.y - cy * sx * p.z,

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -144,7 +144,7 @@ const apiOptions = [
   {
     name: 'markers',
     type: 'Marker[]',
-    desc: '{ location: [lat, lon], size, color?, id? }',
+    desc: '{ location: [lat, lon], size, color?, elevation?, id? }',
   },
   {
     name: 'arcs',
@@ -161,7 +161,7 @@ const apiOptions = [
   {
     name: 'markerElevation',
     type: 'number',
-    desc: 'Marker height above surface (0 to 0.2)',
+    desc: 'Default marker height above surface (0 to 0.2). Overridable per marker via elevation.',
   },
   { name: 'scale', type: 'number', desc: 'Globe scale multiplier (default 1)' },
   { name: 'offset', type: '[x,y]', desc: 'Pixel offset from center [x, y]' },


### PR DESCRIPTION
Add optional `fromElevation` and `toElevation` properties to the `Arc` interface, mirroring the existing per-marker elevation pattern (see #113).

When set, the arc endpoint uses `GLOBE_R + fromElevation / toElevation` instead of the global `markerElevation` uniform. When omitted, behavior is unchanged.

## Usage

```js
arcs: [{
    from: [lat1, lon1],
    to: [lat2, lon2],
    fromElevation: 0, // matches a marker with elevation: 0
    toElevation: 0,
}]
```

Omitting either property falls back to the global `markerElevation`.